### PR TITLE
Configuration of delegate task moved away from task configuration phase

### DIFF
--- a/src/integrationTest/kotlin/io/github/kartashovaa/teddi/TestDiffTest.kt
+++ b/src/integrationTest/kotlin/io/github/kartashovaa/teddi/TestDiffTest.kt
@@ -264,7 +264,13 @@ class TestDiffTest {
     @Test
     fun testDoesNotAffectedByPluginDirectly() {
         project.createMinimalRootProject()
-        val app = project.createAndroidApplicationModule(name = "app")
+        val app = project.createAndroidApplicationModule(
+            name = "app",
+            extraConfiguration = """
+                tasks.all { /* trigger all task configuration */ }
+            """.trimIndent()
+        )
+
         app.kotlin("com.example.app.MainViewModel", DEFAULT_VIEW_MODEL_CONTENT)
         app.kotlin("com.example.app.MainViewModelTest", DEFAULT_VIEWMODEL_TEST_CONTENT, "test")
 

--- a/src/integrationTest/kotlin/io/github/kartashovaa/teddi/util/ProjectWriterDsl.kt
+++ b/src/integrationTest/kotlin/io/github/kartashovaa/teddi/util/ProjectWriterDsl.kt
@@ -21,6 +21,7 @@ fun TeddiProjectWriter.createMinimalSubProject(name: String): TeddiProjectWriter
 fun TeddiProjectWriter.createAndroidApplicationModule(
     name: String = "app",
     dependencies: List<String> = emptyList(),
+    @Language("groovy")
     extraConfiguration: String = ""
 ): TeddiProjectWriter {
     return createMinimalSubProject(name).apply {

--- a/src/main/kotlin/io/github/kartashovaa/teddi/TestDiffTask.kt
+++ b/src/main/kotlin/io/github/kartashovaa/teddi/TestDiffTask.kt
@@ -122,10 +122,12 @@ abstract class TestDiffTask : DefaultTask() {
             filter.set(delegate.filter)
             setVerbose(project.properties["teddi.verbose"]?.toString().toBoolean())
             dependsOn(delegate.classpath)
-            delegate.dependsOn(this) // cancel running delegate if this task failed
-            delegate.onlyIf(OnlyIfHasFiltersSpec())
             finalizedBy(delegate)
 
+            doFirst {
+                delegate.dependsOn(this) // cancel running delegate if this task failed
+                delegate.onlyIf(OnlyIfHasFiltersSpec())
+            }
             group = delegate.group
             description = "Runs tests for changed files"
             TaskCompat.notCompatibleWithConfigurationCache(


### PR DESCRIPTION
Problem: if project evaluates all tasks(uses tasks.all({}) or similar method) and executes main test task(testUnitTest), then no tasks will be executed.